### PR TITLE
Fixes for memory usage and units

### DIFF
--- a/Converting/python/Convert_to_h5.py
+++ b/Converting/python/Convert_to_h5.py
@@ -157,7 +157,7 @@ def convertFile(inFile, outFile):
             myFeatures.add("HCAL", HCALarray)
 
             # Truth info from txt file
-            myFeatures.add("energy", my_event['E'])
+            myFeatures.add("energy", my_event['E']/1000.) # convert MeV to GeV
             myFeatures.add("pdgID", my_event['pdgID'])
 
     # Save features to an h5 file


### PR DESCRIPTION
- Loop over input txt file line-by-line (event-by-event) to avoid reading full file into memory.
- Save true energy in units of GeV instead of MeV to match reco values